### PR TITLE
fix index.d.tx

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ interface textDbFieldsMap {}
 interface options {
     log: string;
     dbCode: number;
-    noConvertDbCodes: Array
+    noConvertDbCodes: Array<number>
 }
 
 declare function dbORM(
@@ -68,10 +68,10 @@ declare namespace dbORM {
     interface ORM_DB {
         pool: mysql.Pool,
         getConnection(): Promise<mysql.Connection>,
-        wrapTransaction(fn: Function, nth: number): Promise<any>,
-        query(sql: string, sql: Array, connection?: mysql.Connection): Promise<any>,
+        wrapTransaction(fn: Function, nth: number): Function,
+        query(sql: string, params: Array<any>, connection?: mysql.Connection): Promise<any>,
         beginTransaction(): Promise<mysql.Connection>,
-        commitTransaction(conn: mysql.Connection): Promise<>,
+        commitTransaction(conn: mysql.Connection): Promise<any>,
         rollbackTransaction(conn: mysql.Connection): Promise<any>
     }
 


### PR DESCRIPTION
webstorm 无法识别被 db.wrapTransaction 包裹的东西，不认为这个是函数，调用的时候会飘波浪线。